### PR TITLE
feat: animate user selection with anime.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "video-party-react",
       "version": "0.0.0",
       "dependencies": {
+        "animejs": "^4.1.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1332,6 +1333,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/animejs": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/animejs/-/animejs-4.1.3.tgz",
+      "integrity": "sha512-4XzlIsQsku1ycSPzchxxT0N+ohEMZObG71nOSBBkZoV4sgQvtXa/qAANkFpTE6pegdV8JnIBZiB0LfdxNoRNMw==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "animejs": "^4.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/components/UserSelectScreen.jsx
+++ b/src/components/UserSelectScreen.jsx
@@ -1,6 +1,20 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import anime from 'animejs/lib/anime.es.js'
 
 const UserSelectScreen = ({ isActive, onUserSelect }) => {
+  useEffect(() => {
+    if (isActive) {
+      anime.set('.user-card', { opacity: 0, translateY: 20 })
+      anime({
+        targets: '.user-card',
+        opacity: 1,
+        translateY: 0,
+        delay: anime.stagger(100),
+        easing: 'easeOutQuad'
+      })
+    }
+  }, [isActive])
+
   return (
     <div className={`screen ${isActive ? 'active' : ''}`}>
       <div className="select-user-card">


### PR DESCRIPTION
## Summary
- add anime.js dependency
- animate user selection cards when screen becomes active

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bccd7e4b4c8325b0351fa46863de2d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added animated entrance for user cards on the User Selection screen. Cards now fade in and slide upward with a subtle stagger when the screen becomes active, improving visual polish and perceived responsiveness.

- Chores
  - Updated dependencies to support the new animation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->