### PR TITLE
Fix anime.js import path for Vite compatibility

### DIFF
--- a/src/components/UserSelectScreen.jsx
+++ b/src/components/UserSelectScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import anime from 'animejs/lib/anime.es.js'
+import anime from 'animejs'
 
 const UserSelectScreen = ({ isActive, onUserSelect }) => {
   useEffect(() => {


### PR DESCRIPTION
## Summary
- fix animejs import path in `UserSelectScreen` to use package root

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68bccf3f63608325a0cb90b6d47667ce